### PR TITLE
Phase Two changes: Part One

### DIFF
--- a/assets/javascripts/discourse/initializers/x-chat-init.gjs
+++ b/assets/javascripts/discourse/initializers/x-chat-init.gjs
@@ -1,0 +1,26 @@
+import { withPluginApi } from "discourse/lib/plugin-api";
+import { tracked } from "@glimmer/tracking";
+import Category from "discourse/models/category";
+import { service } from "@ember/service";
+
+const PLUGIN_ID = "x-chat-customisations";
+const MIN_HEIGHT_TIMELINE = 325;
+
+export default {
+  name: "x-chat-init",
+  initialize(application) {
+    withPluginApi("0.8.40", (api) => {
+      api.modifyClass("component:chat/modal/create-channel", 
+        (Superclass) =>
+            class extends Superclass {
+              @service siteSettings;
+
+              @tracked categoryId = this.siteSettings.x_chat_customisations_private_chat_dummy_category_id; // property already exists, but let's add a default value.
+              @tracked category = Category.findById(this.categoryId);
+              @tracked threadingEnabled = true;
+              @tracked autoJoinUsers = true;
+            }
+        );
+    });
+  },
+};

--- a/assets/stylesheets/common/x_chat_common.scss
+++ b/assets/stylesheets/common/x_chat_common.scss
@@ -1,0 +1,3 @@
+div.chat-modal-create-channel__control.-threading-toggle {
+  display: none;
+}

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -8,3 +8,8 @@ plugins:
   x_chat_customisations_chat_summary_emails_enabled:
     default: true
     client: false
+  x_chat_customisations_private_chat_dummy_category_id:
+    type: category
+    client: true
+    default: 4
+

--- a/lib/chat_customisations/api_channel_controller_extension.rb
+++ b/lib/chat_customisations/api_channel_controller_extension.rb
@@ -1,0 +1,22 @@
+#frozen_string_literal: true
+module ChatCustomisations
+  module ApiChannelControllerExtension
+    def create
+      if (params.dig(:channel, :chatable_id)&.== SiteSetting.x_chat_customisations_private_chat_dummy_category_id.to_s) && params[:channel][:name].present?
+        name = params[:channel][:name]
+        if Category.exists?(name: name) || Group.exists?(name: name)
+            raise Discourse::InvalidParameters.new("A Category or Group with the name #{name} already exists, choose a different name")
+        end
+        category = Category.new(name: name, user_id: current_user.id)
+        category.save!
+        params[:channel][:chatable_id] = category.id
+        group = Group.new(name: name)
+        group.save!
+        CategoryGroup.where(category_id: category.id).destroy_all
+        cg = CategoryGroup.create!(category_id: category.id, group_id: group.id, permission_type: CategoryGroup.permission_types[:full]) 
+        gu = GroupUser.create!(group_id: group.id, user_id: current_user.id)
+      end
+      super
+    end
+  end
+end

--- a/lib/chat_customisations/api_channel_controller_extension.rb
+++ b/lib/chat_customisations/api_channel_controller_extension.rb
@@ -5,7 +5,7 @@ module ChatCustomisations
       if (params.dig(:channel, :chatable_id)&.== SiteSetting.x_chat_customisations_private_chat_dummy_category_id.to_s) && params[:channel][:name].present?
         name = params[:channel][:name]
         if Category.exists?(name: name) || Group.exists?(name: name)
-            raise Discourse::InvalidParameters.new("A Category or Group with the name #{name} already exists, choose a different name")
+          raise Discourse::InvalidParameters.new("A Category or Group with the name #{name} already exists, choose a different name")
         end
         category = Category.new(name: name, user_id: current_user.id)
         category.save!
@@ -13,7 +13,7 @@ module ChatCustomisations
         group = Group.new(name: name)
         group.save!
         CategoryGroup.where(category_id: category.id).destroy_all
-        cg = CategoryGroup.create!(category_id: category.id, group_id: group.id, permission_type: CategoryGroup.permission_types[:full]) 
+        cg = CategoryGroup.create!(category_id: category.id, group_id: group.id, permission_type: CategoryGroup.permission_types[:full])
         gu = GroupUser.create!(group_id: group.id, user_id: current_user.id)
       end
       super

--- a/lib/chat_customisations/category_channel_extension.rb
+++ b/lib/chat_customisations/category_channel_extension.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+module ChatCustomisations
+  module CategoryChannelExtension
+    extend ActiveSupport::Concern
+
+    included do
+      after_initialize :default_allow_channel_wide_mentions
+    end
+
+    private
+
+    def default_allow_channel_wide_mentions
+      self.allow_channel_wide_mentions = false
+    end
+  end
+end

--- a/lib/chat_customisations/channel_delete_job_extension.rb
+++ b/lib/chat_customisations/channel_delete_job_extension.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ChatCustomisations
   module ChannelDeleteJobExtension
     def execute(args = {})

--- a/lib/chat_customisations/channel_delete_job_extension.rb
+++ b/lib/chat_customisations/channel_delete_job_extension.rb
@@ -1,0 +1,21 @@
+module ChatCustomisations
+  module ChannelDeleteJobExtension
+    def execute(args = {})
+      name = args[:channel_name]
+      super
+      if name
+        group = Group.find_by(name: name)
+        category = Category.find_by(name: name)
+        if group
+          GroupUser.where(group_id: group.id).destroy_all
+          group.destroy
+        end
+        if category
+          CategoryGroup.where(category_id: category.id).destroy_all
+          Topic.where(category_id: category.id).destroy_all
+          category.destroy
+        end
+      end
+    end
+  end
+end

--- a/lib/chat_customisations/trash_channel_extension.rb
+++ b/lib/chat_customisations/trash_channel_extension.rb
@@ -1,0 +1,7 @@
+module ChatCustomisations
+  module TrashChannelExtension
+    def enqueue_delete_channel_relations_job(channel:)
+      Jobs.enqueue(Jobs::Chat::ChannelDelete, chat_channel_id: channel.id, channel_name: channel.name)
+    end
+  end
+end

--- a/lib/chat_customisations/trash_channel_extension.rb
+++ b/lib/chat_customisations/trash_channel_extension.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ChatCustomisations
   module TrashChannelExtension
     def enqueue_delete_channel_relations_job(channel:)

--- a/plugin.rb
+++ b/plugin.rb
@@ -6,6 +6,7 @@
 # url: https://github.com/merefield/x-chat-customisations
 
 enabled_site_setting :x_chat_customisations_enabled
+register_asset 'stylesheets/common/x_chat_common.scss'
 
 module ::ChatCustomisations
   PLUGIN_NAME = "chat-customisations".freeze
@@ -16,6 +17,12 @@ require_relative "lib/chat_customisations/engine"
 after_initialize do
   reloadable_patch do
     Chat::Mailer.singleton_class.prepend(ChatCustomisations::ChatMailerExtension)
+    Chat::CategoryChannel.include(ChatCustomisations::CategoryChannelExtension)
     Jobs::UserEmail.prepend(ChatCustomisations::UserEmailJobExtension)
+    Chat::TrashChannel.prepend(ChatCustomisations::TrashChannelExtension)
+    Jobs::Chat::ChannelDelete.prepend(ChatCustomisations::ChannelDeleteJobExtension)
+    Chat::Api::ChannelsController.prepend(ChatCustomisations::ApiChannelControllerExtension)
   end
+
+  Jobs::Chat::AutoJoinUsers.every 10.minutes
 end


### PR DESCRIPTION
New Channel Setup:

* Default the Category to "General" or whatever is set in new plugin setting.
* Default Enable Threading to true
* Hide Enable Threading
* Default Channel Wide Mentions to off
* Auto-join defaulted to true (mainly for private channels)

New Channel Setup "Middleware":
* Creating a new Chat channel in the "dummy" Category will
  * create a new Category
  * create a new Group
  * add that Group as the only Group permissioned in the new Category
  * adds the requesting User who set up the channel to that Group as owner
 * Staff and User now able to or remove Users to that Group.
 * Autojoin channel job which used to run once an hour now runs every 10 minutes - anyone added to the Group will be added to the Private Chat Channel within 10 minutes.

